### PR TITLE
Copy binary from upstream image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: fetch minsign 0.8 release
+      - name: fetch minsign 0.10 release
         run: |
           wget \
-            https://github.com/jedisct1/minisign/releases/download/0.8/minisign-0.8.tar.gz \
-            https://github.com/jedisct1/minisign/releases/download/0.8/minisign-0.8.tar.gz.minisig
-      - name: verify minisign 0.8 release
+            https://github.com/jedisct1/minisign/archive/refs/tags/0.10.tar.gz \
+            https://github.com/jedisct1/minisign/releases/download/0.10/0.10.tar.gz.minisig
+      - name: verify minisign 0.10 release
         uses: ./
         with:
-          args: -Vm "minisign-0.8.tar.gz" -P "RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3"
+          args: -Vm "0.10.tar.gz" -P "RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3"
 
   sign:
     name: "Sign"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,6 @@
-FROM ubuntu:18.04 AS build
+FROM jedisct1/minisign as minisign
 
-# We're pulling a specific tag/commit because minisign hasn't been released in a
-# long time and we want to build a static artifact.
-ENV TAG="0.9"
-
-# Setup Deps
-RUN apt-get update && \
-    apt-get install -y cmake libsodium-dev pkg-config
-
-# Download
-ADD https://github.com/jedisct1/minisign/archive/$TAG.tar.gz /minisign.tgz
-
-# Extract
-RUN tar -xzf /minisign.tgz
-
-# Build
-WORKDIR /minisign-$TAG/build
-RUN cmake -D BUILD_STATIC_EXECUTABLES=1 ..
-RUN make install
-
-# Copy over built artifact into empty container
 FROM alpine:latest
-
-COPY --from=build /usr/local/bin/minisign /minisign
-
+COPY --from=minisign /usr/local/bin/minisign /minisign
 ADD entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
@ jedisct1 has a [Docker image](https://hub.docker.com/r/jedisct1/minisign) for minisign.

This way, the final image could be cached, most certainly outperforming building it every time.